### PR TITLE
update `signing.ts` to latest available `build-tools` version

### DIFF
--- a/src/signing.ts
+++ b/src/signing.ts
@@ -15,7 +15,7 @@ export async function signApkFile(
     core.debug("Zipaligning APK file");
 
     // Find zipalign executable
-    const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '29.0.3';
+    const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '34.0.0';
     const androidHome = process.env.ANDROID_HOME;
     const buildTools = path.join(androidHome!, `build-tools/${buildToolsVersion}`);
     if (!fs.existsSync(buildTools)) {


### PR DESCRIPTION
https://github.com/open-learning-exchange/myplanet/actions/runs/7487925634/job/20381321971#step:9:1
is happening because
ubuntu latest go the old sdk's removed https://github.com/actions/runner-images/pull/9094
with
```
$ tree ${ANDROID_SDK_ROOT} -f | grep zipalign
│   │   └── /usr/local/lib/android/sdk/build-tools/31.0.0/zipalign
│   │   └── /usr/local/lib/android/sdk/build-tools/32.0.0/zipalign
│   │   └── /usr/local/lib/android/sdk/build-tools/33.0.0/zipalign
│   │   └── /usr/local/lib/android/sdk/build-tools/33.0.1/zipalign
│   │   └── /usr/local/lib/android/sdk/build-tools/33.0.2/zipalign
│       └── /usr/local/lib/android/sdk/build-tools/34.0.0/zipalign
```
we see the available build-tools version ...